### PR TITLE
Added wip example configuration file

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -1,0 +1,26 @@
+# Your one.com login.
+username="email.address@example.com"
+password="Your Beautiful Password"
+
+# Your domain ( Not www.example.com, only example.com ).
+domain="example.com"
+
+# List of subdomains you want pointing to your ip.
+subdomains = ["myddns"]
+# subdomains = ["mutiple", "subdomains"]
+
+# Your ip address.
+ip="auto"
+# 'const:127.0.0.1' -> IP Address.
+# 'auto'            -> Automatically detect using ipify.org .
+# 'arg'             -> Read from commandline argument (example: $ python3 ddns.py 127.0.0.1).
+
+
+# Check if ip address has changed since last script execution?
+check_ip_change = true
+# true = only continue when ip has changed.
+# false = always continue.
+
+# Cache path where last ip should be saved inbetween script executions.
+# Not needed if check_ip_change is set to false.
+last_ip_cache = "/var/run/one.com-ddns-python-script/lastip.txt"


### PR DESCRIPTION
This configuration file makes some changes to those found in one_com_ddns.py .
Everything has been rewritten to no longer use capital lettering as they are no longer denoted python constant variables.

ip setting has been changes slightly as to increase clarity. It hit me that a user might want to not point to an ip but another domain. Adding the prefix const: infront of the ip would allow one to point their ip to a domain called 'auto' or 'arg'. 
Example: "const:auto" would point to the domain "auto" and not make the script run in auto mode.

LAST_IP_FILE was renamed last_ip_cache as it better reflect that its a cache. The default value is set to a linux runtime temporary location which will be cleared for every reboot. It has to be created manually if it does not exists.

Implementation of reading this config file is on it's way.